### PR TITLE
feat: Add a chart for Day tab on History page #CRE8-163

### DIFF
--- a/frontend/features/history/components/Chart.tsx
+++ b/frontend/features/history/components/Chart.tsx
@@ -13,7 +13,7 @@ type Props = {
 
 export const Chart = ({data, viewMode}: Props) => {
   const font = useFont(interFont, 14);
-  const {state, isActive} = useChartPressState({x: 0, y: {hours: 0, alerts: 0}});
+  const {state, isActive} = useChartPressState({x: 0, y: {alerts: 0}});
 
   return (
     <View style={styles.chartContainer}>
@@ -21,19 +21,23 @@ export const Chart = ({data, viewMode}: Props) => {
         chartPressState={state}
         data={data}
         xKey="id"
-        yKeys={['hours', 'alerts']}
+        yKeys={['alerts']}
         domainPadding={
-          viewMode === 'week'
-            ? {left: 25, right: 25, top: 50}
-            : viewMode === 'month'
-              ? {left: 5, right: 5, top: 50}
-              : {left: 15, right: 15, top: 50}
+          viewMode === 'day'
+            ? {left: 5, right: 5, top: 50}
+            : viewMode === 'week'
+              ? {left: 25, right: 25, top: 50}
+              : viewMode === 'month'
+                ? {left: 5, right: 5, top: 50}
+                : {left: 15, right: 15, top: 50}
         }
         axisOptions={{
           font,
           tickCount: data.length,
           formatXLabel(value) {
-            if (viewMode === 'week') {
+            if (viewMode === 'day') {
+              return [3, 6, 9, 12, 15, 18, 21].includes(value) ? value.toString() : '';
+            } else if (viewMode === 'week') {
               const daysOfWeek = ['Sun', 'Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat'];
               return daysOfWeek[(value - 1) % 7];
             } else if (viewMode === 'month') {
@@ -44,44 +48,31 @@ export const Chart = ({data, viewMode}: Props) => {
         }}
         yAxis={[
           {
-            // yKeys: ['hours'],
             font,
             axisSide: 'left',
-            // domain: [0, 100],
-            // tickValues: [0, 50, 100],
-            // enableRescaling: true,
           },
-          // {
-          //   yKeys: ['alerts'],
-          //   font,
-          //   axisSide: 'right',
-          //   domain: [0, 50],
-          //   tickValues: [0, 10, 20, 30],
-          //   labelColor: '#FF7E5F',
-          //   enableRescaling: true,
-          // },
         ]}>
         {({points, chartBounds}) => (
           <View>
             <Bar
               chartBounds={chartBounds}
-              points={points.hours}
+              points={points.alerts}
               innerPadding={0.5}
               animate={{type: 'timing', duration: 500}}>
               <LinearGradient start={vec(0, 0)} end={vec(0, 400)} colors={['#2089DC', '#155FA2']} />
             </Bar>
-            <Line
+            {/* <Line
               points={points.alerts}
               color="#FF758C"
               strokeWidth={3}
               animate={{type: 'timing', duration: 500}}
-            />
+            /> */}
             {isActive && font && (
               <Tooltip
                 xCoordinate={state.x.position}
-                yCoordinate={state.y.hours.position}
+                yCoordinate={state.y.alerts.position}
                 date={state.x.value}
-                hours={state.y.hours.value}
+                hours={state.y.alerts.value}
               />
             )}
           </View>

--- a/frontend/features/history/components/HistoryView.tsx
+++ b/frontend/features/history/components/HistoryView.tsx
@@ -14,16 +14,19 @@ export const HistoryView = () => {
   const data = useChartDataDummy(viewMode, startDate);
 
   // --- Under development
-  const {alert_data, fd_data} = useChartData(viewMode, startDate);
+  const {data: hourlyData} = useChartData(viewMode, startDate);
   useEffect(() => {
-    console.log('Alert data:', JSON.stringify(alert_data, null, 2));
-    console.log('FD Session data:', JSON.stringify(fd_data, null, 2));
-  }, [alert_data, fd_data]);
+    console.log('Hourly Alert Data:', JSON.stringify(hourlyData, null, 2));
+  }, [hourlyData]);
   // --- Under development
 
   const legendItems = [
-    {label: 'Legend1 TBD', color: '#00C9FF'},
-    {label: 'Legend2 TBD', color: '#FF758C'},
+    {
+      label: 'Alert received/hour',
+      color: '#2089DC',
+      description:
+        'This is calculated by dividing the total daily alerts by the "Hours with Detection" for that day.',
+    },
   ];
 
   return (
@@ -31,12 +34,12 @@ export const HistoryView = () => {
       <ViewModeButtons viewMode={viewMode} setViewMode={setViewMode} />
       <SummaryCard data={data} viewMode={viewMode} />
       <ChartPager viewMode={viewMode} startDate={startDate} setStartDate={setStartDate} />
-      {viewMode !== 'day' && <Chart data={data} viewMode={viewMode} />}
-      {viewMode !== 'day' && <Legend legend={legendItems} />}
+      <Chart data={data} viewMode={viewMode} />
+      <Legend legend={legendItems} />
     </View>
   );
 };
 
 const styles = StyleSheet.create({
-  container: {flex: 1, gap: 10, padding: 10},
+  container: {flex: 1, gap: 20, padding: 20},
 });

--- a/frontend/features/history/components/Legend.tsx
+++ b/frontend/features/history/components/Legend.tsx
@@ -4,6 +4,7 @@ import {View, Text, StyleSheet} from 'react-native';
 type LegendItem = {
   label: string;
   color: string;
+  description: string;
 };
 
 type Props = {
@@ -14,9 +15,12 @@ export const Legend = ({legend}: Props) => {
   return (
     <View style={styles.container}>
       {legend.map((item, index) => (
-        <View key={index} style={styles.itemContainer}>
-          <View style={[styles.colorBox, {backgroundColor: item.color}]} />
-          <Text style={styles.label}>{item.label}</Text>
+        <View key={index}>
+          <View style={styles.itemContainer}>
+            <View style={[styles.colorBox, {backgroundColor: item.color}]} />
+            <Text style={styles.label}>{item.label}</Text>
+          </View>
+          <Text>{item.description}</Text>
         </View>
       ))}
     </View>
@@ -27,7 +31,7 @@ const styles = StyleSheet.create({
   container: {
     flexDirection: 'row',
     flexWrap: 'wrap',
-    justifyContent: 'center',
+    justifyContent: 'flex-start',
   },
   itemContainer: {
     flexDirection: 'row',

--- a/frontend/features/history/components/SummaryCard.tsx
+++ b/frontend/features/history/components/SummaryCard.tsx
@@ -16,7 +16,7 @@ export const SummaryCard = ({data, viewMode}: Props) => {
       <View style={styles.contentContainer}>
         <View style={styles.content}>
           <Text style={styles.contentTitle}>{totalHours}</Text>
-          <Text>hours</Text>
+          <Text>hours with detection</Text>
         </View>
         <View style={styles.content}>
           <Text style={styles.contentTitle}>{totalAlerts}</Text>

--- a/frontend/features/history/hooks/useChartData.ts
+++ b/frontend/features/history/hooks/useChartData.ts
@@ -1,33 +1,64 @@
+import {useState, useEffect} from 'react';
 import {ViewMode} from '@/features/history/types/ViewMode';
-import {useAlertData} from '@/features/history/hooks/useAlertData';
-import {useFDSessionData} from '@/features/history/hooks/useFDSessionData';
+import {AlertService} from '@/services/AlertService';
 // import {getDriverByID, getAllHistoryFromDriver, getHistoryByID} from '@/api/api';
 
+type DailyAlertPerHour = {
+  hour: number;
+  count: number;
+};
+
+type WeeklyAlertPerHour = {
+  date: string;
+  alertsPerHour: number;
+};
+
+type MonthlyAlertPerHour = {
+  date: string;
+  alertsPerHour: number;
+};
+
+type YearlyAlertPerHour = {
+  date: string;
+  alertsPerHour: number;
+};
+
 export const useChartData = (viewMode: ViewMode, startDate: Date) => {
-  const {alert_data} = useAlertData(viewMode, startDate);
-  const {fd_data} = useFDSessionData(viewMode, startDate);
-  return {alert_data, fd_data};
+  const [data, setData] = useState<WeeklyAlertPerHour[]>([]);
+  const [loading, setLoading] = useState(true);
+
+  const fetchData = async () => {
+    try {
+      setLoading(true);
+      const data = await AlertService.getWeeklyAlertPerHour(startDate.toISOString());
+      setData(data);
+    } catch (error) {
+      console.error(error);
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  useEffect(() => {
+    fetchData();
+  }, [viewMode, startDate]);
+
+  return {data, loading};
 };
 
 export const useChartDataDummy = (viewMode: ViewMode, startDate: Date) => {
-  // TODO:
-  // This part will be replaced by fetching data through APIs
-  // Now, it generates dummy data for sandbox
-
   const maxHoursValues = {
-    day: 15,
+    day: 2,
     week: 15,
     month: 15,
     year: 300,
   };
-
   const maxAlertValues = {
     day: 5,
     week: 5,
-    month: 5,
+    month: 10,
     year: 100,
   };
-
   const maxHours = maxHoursValues[viewMode] || 0;
   const maxAlerts = maxAlertValues[viewMode] || 0;
 
@@ -50,7 +81,7 @@ export const useChartDataDummy = (viewMode: ViewMode, startDate: Date) => {
   // }, []);
 
   return Array.from(
-    {length: viewMode === 'day' ? 1 : viewMode === 'week' ? 7 : viewMode === 'month' ? 30 : 12},
+    {length: viewMode === 'day' ? 24 : viewMode === 'week' ? 7 : viewMode === 'month' ? 30 : 12},
     (_, index) => ({
       id: index + 1,
       hours: Math.floor(Math.random() * maxHours),

--- a/frontend/features/safety-alert/components/CameraView.tsx
+++ b/frontend/features/safety-alert/components/CameraView.tsx
@@ -6,7 +6,7 @@ import {
   Camera as VisionCamera,
 } from 'react-native-vision-camera';
 import FaceDetection from '@/features/safety-alert/components/FaceDetection';
-import {Button} from '@rneui/themed';
+import {Button, Icon} from '@rneui/themed';
 
 type Props = {
   isCameraActive: boolean;
@@ -32,12 +32,13 @@ export const CameraView = ({isCameraActive, setIsCameraActive}: Props) => {
   ) : (
     <View style={styles.container}>
       <Button
-        title="Start Detection"
         titleStyle={styles.buttonText}
         buttonStyle={styles.roundButton}
         containerStyle={styles.roundButton}
-        onPress={() => setIsCameraActive(true)}
-      />
+        onPress={() => setIsCameraActive(true)}>
+        <Icon name={'videocam'} color={'white'} size={50} />
+        Start Detection
+      </Button>
     </View>
   );
 };
@@ -54,6 +55,7 @@ const styles = StyleSheet.create({
     borderRadius: 75,
     justifyContent: 'center',
     alignItems: 'center',
+    flexDirection: 'column',
   },
   buttonText: {
     color: 'white',

--- a/frontend/services/AlertService.ts
+++ b/frontend/services/AlertService.ts
@@ -1,6 +1,13 @@
+import {sql} from 'drizzle-orm';
 import {drizzleDb} from '@/db/db';
 import {alert} from '@/db/schema';
 import {AlertType} from '@/types/AlertType';
+import {faceDetectionSession} from '@/db/schema';
+
+const TIMEZONE = {
+  NAME: 'America/Vancouver',
+  SQL_OFFSET: '-8 hours',
+};
 
 export const AlertService = {
   async getAllAlerts(): Promise<AlertType[]> {
@@ -20,5 +27,81 @@ export const AlertService = {
       throw error;
     }
     console.log('AlertService>logAlert:', newAlert);
+  },
+
+  async getDailyAlertPerHour(date: string): Promise<{hour: number; count: number}[]> {
+    console.log(`date: ${date}`);
+    try {
+      const result = await drizzleDb
+        .select({
+          hour: sql`strftime('%H', ${alert.timestamp})`.as('hour'),
+          count: sql`COUNT(*)`.as('count'),
+        })
+        .from(alert)
+        .where(sql`date(${alert.timestamp}) = date(${date})`)
+        .groupBy(sql`strftime('%H', ${alert.timestamp})`)
+        .orderBy(sql`hour`);
+
+      return result.map(row => ({
+        hour: parseInt(row.hour as string, 10),
+        count: row.count as number,
+      }));
+    } catch (error) {
+      console.error('Failed to retrieve hourly alert counts:', error);
+      throw error;
+    }
+  },
+
+  async getWeeklyAlertPerHour(date: string): Promise<{date: string; alertsPerHour: number}[]> {
+    try {
+      const weekDates = Array.from({length: 7}, (_, i) => {
+        const d = new Date(date);
+        d.setDate(d.getDate() - d.getDay() + i);
+        return d.toLocaleDateString('en-CA', {timeZone: TIMEZONE.NAME});
+      });
+
+      const result = await drizzleDb
+        .select({
+          date: sql`date(datetime(${faceDetectionSession.sessionStartDate}, ${TIMEZONE.SQL_OFFSET}))`.as(
+            'date',
+          ),
+          totalSessionSeconds: sql`SUM(${faceDetectionSession.sessionDuration})`.as(
+            'totalSessionSeconds',
+          ),
+          totalAlerts: sql`COUNT(${alert.alertId})`.as('totalAlerts'),
+        })
+        .from(faceDetectionSession)
+        .leftJoin(
+          alert,
+          sql`${faceDetectionSession.faceDetectionSessionId} = ${alert.faceDetectionSessionId}`,
+        )
+        .where(
+          sql`date(datetime(${faceDetectionSession.sessionStartDate}, ${TIMEZONE.SQL_OFFSET})) BETWEEN date(${weekDates[0]}) AND date(${weekDates[6]})`,
+        )
+        .groupBy(
+          sql`date(datetime(${faceDetectionSession.sessionStartDate}, ${TIMEZONE.SQL_OFFSET}))`,
+        )
+        .orderBy(
+          sql`date(datetime(${faceDetectionSession.sessionStartDate}, ${TIMEZONE.SQL_OFFSET})) ASC`,
+        );
+
+      const resultMap = new Map(
+        result.map(row => {
+          const totalSessionHours = row.totalSessionSeconds
+            ? Number(row.totalSessionSeconds) / 3600
+            : 0;
+          const totalAlerts = row.totalAlerts ? Number(row.totalAlerts) : 0;
+          const alertsPerHour = totalSessionHours > 0 ? totalAlerts / totalSessionHours : 0;
+          return [row.date as string, parseFloat(alertsPerHour.toFixed(2))];
+        }),
+      );
+
+      return weekDates.map(date => ({
+        date,
+        alertsPerHour: resultMap.get(date) ?? 0,
+      }));
+    } catch (error) {
+      throw error;
+    }
   },
 };

--- a/frontend/types/FDSessionType.ts
+++ b/frontend/types/FDSessionType.ts
@@ -1,7 +1,7 @@
 export type FDSessionType = {
   faceDetectionSessionId: string;
   userId: string;
-  startTime?: string;
+  startTime?: string | null;
   endTime?: string | null;
   sessionDuration?: number | null;
   sessionStartDate?: string | null;


### PR DESCRIPTION
Added a chart to "Day" tab on the History page according to the modification of our wireframe.

Also, I reflected the following minor updates.
- The graph display data has been changed from two metrics—driving time and the number of alerts—to a single metric: the number of alerts per hour.

- Accordingly, the two scales previously displayed on the left and right sides of the Y-axis have been consolidated into a single scale on the left side only.

* This version is still using dummy data for the history graph. Now, I'm developing the services modules (data handling module) communicating to the local database (SQLite)