### PR TITLE
fix: add eye icon on password input box on Sign-in and Sign-up page

### DIFF
--- a/frontend/app/signIn.tsx
+++ b/frontend/app/signIn.tsx
@@ -19,6 +19,7 @@ import Onboarding from '@/components/Onboarding';
 import {Input} from 'react-native-elements';
 import {LinearGradient} from 'expo-linear-gradient';
 import {ensureDefaultSettings} from '@/utils/utils';
+import {Icon} from '@rneui/themed';
 
 export default function SignInScreen() {
   const {showOnboardingSlide} = useLocalSearchParams();
@@ -41,6 +42,11 @@ const SignInForm = () => {
   const [email, setEmail] = useState('');
   const [password, setPassword] = useState('');
   const [focusedInput, setFocusedInput] = useState<string | null>(null);
+  const [passwordVisible, setPasswordVisible] = useState(false);
+
+  const togglePasswordVisibility = () => {
+    setPasswordVisible(!passwordVisible);
+  };
 
   const handleAuth = async () => {
     try {
@@ -75,7 +81,7 @@ const SignInForm = () => {
           fontWeight: '400',
           color: '#1E3A8A',
         }}
-        placeholder="Email"
+        placeholder="Your email address"
         value={email}
         onChangeText={setEmail}
         onFocus={() => setFocusedInput('email')}
@@ -115,10 +121,10 @@ const SignInForm = () => {
           fontWeight: '400',
           color: '#1E3A8A',
         }}
-        placeholder="Password"
+        placeholder="Your password"
         value={password}
         onChangeText={setPassword}
-        secureTextEntry
+        secureTextEntry={!passwordVisible}
         onFocus={() => setFocusedInput('password')}
         onBlur={() => setFocusedInput(null)}
         containerStyle={{
@@ -137,6 +143,16 @@ const SignInForm = () => {
           fontSize: 18,
           color: '#333',
         }}
+        rightIcon={
+          <TouchableOpacity onPress={togglePasswordVisibility}>
+            <Icon
+              name={passwordVisible ? 'eye-off' : 'eye'}
+              type="material-community"
+              color="rgba(30, 58, 138, 0.6)"
+              size={20}
+            />
+          </TouchableOpacity>
+        }
       />
       {/* <TextInput
         placeholder="Password"

--- a/frontend/app/signUp.tsx
+++ b/frontend/app/signUp.tsx
@@ -31,6 +31,7 @@ import {useOnboardingTourContext} from '@/contexts/OnboardingTourProvider';
 import {Input} from 'react-native-elements';
 import {LinearGradient} from 'expo-linear-gradient';
 import {ensureDefaultSettings} from '@/utils/utils';
+import {Icon} from '@rneui/themed';
 
 export default function SignUpScreen() {
   const router = useRouter();
@@ -44,6 +45,11 @@ export default function SignUpScreen() {
   const cameraRef = useRef<Camera>(null);
   const {setShowOnboarding} = useOnboardingTourContext();
   const [focusedInput, setFocusedInput] = useState<string | null>(null);
+  const [passwordVisible, setPasswordVisible] = useState(false);
+
+  const togglePasswordVisibility = () => {
+    setPasswordVisible(!passwordVisible);
+  };
 
   const handleAuth = async () => {
     try {
@@ -176,7 +182,7 @@ export default function SignUpScreen() {
               fontWeight: '400',
               color: '#1E3A8A',
             }}
-            placeholder="Email"
+            placeholder="Your email address"
             value={email}
             onChangeText={setEmail}
             onFocus={() => setFocusedInput('email')}
@@ -216,10 +222,10 @@ export default function SignUpScreen() {
               fontWeight: '400',
               color: '#1E3A8A',
             }}
-            placeholder="Password"
+            placeholder="Your password"
             value={password}
             onChangeText={setPassword}
-            secureTextEntry
+            secureTextEntry={!passwordVisible}
             onFocus={() => setFocusedInput('password')}
             onBlur={() => setFocusedInput(null)}
             containerStyle={{
@@ -238,6 +244,16 @@ export default function SignUpScreen() {
               fontSize: 18,
               color: '#333',
             }}
+            rightIcon={
+              <TouchableOpacity onPress={togglePasswordVisibility}>
+                <Icon
+                  name={passwordVisible ? 'eye-off' : 'eye'}
+                  type="material-community"
+                  color="rgba(30, 58, 138, 0.6)"
+                  size={20}
+                />
+              </TouchableOpacity>
+            }
           />
           {/* <TextInput
             placeholder="Password"


### PR DESCRIPTION
fix: add eye icon on password input box to trigger the password visible or not on Sign-in and Sign-up page